### PR TITLE
Refine entrypoint file

### DIFF
--- a/.github/workflows/tag-latest-green-commit.yml
+++ b/.github/workflows/tag-latest-green-commit.yml
@@ -1,32 +1,35 @@
 name: Tag Latest Green Commit
 
-on:
-  push:
-    branches:
-      - main
+on: push
 
 jobs:
-  build:
+
+  test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
 
-    - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
+      - name: Install Python Packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-    - name: Install Python Packages
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      - name: Run Pytest
+        run: pytest
 
-    - name: Run Pytest
-      run: pytest
+      - name: Build docker
+        run: docker build .
 
-    - name: Build docker
-      run: docker build .
+  tag:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/main'
 
-    - name: Tag if all green
-      run: |
-        git tag latest -f
-        git push origin latest --force
+    steps:
+      - name: Tag if all green
+        run: |
+          git tag latest -f
+          git push origin latest --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:slim-buster
+ENV REPO https://github.com/aarongibbon/image-tools.git
+ENV REPO_TAG latest
 RUN apt-get update && apt-get install -y \
     git
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
-COPY python-image-organiser/ /home/python-image-organiser/
-ENTRYPOINT [ "python", "/home/python-image-organiser/processor.py" ]
+RUN git clone -b $REPO_TAG $REPO /home/code
+RUN pip install -r /home/code/requirements.txt
+ENTRYPOINT [ "python", "/home/code/python-image-organiser/processor.py"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,3 +2,4 @@
 pushd /tmp/code/
 git pull
 git checkout refine-entrypoint-file
+python python-image-organiser/processor.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 pushd /tmp/code/
 git checkout refine-entrypoint-file
 git pull
-python python-image-organiser/processor.py $@
+python -u python-image-organiser/processor.py $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 pushd /tmp/code/
-git pull
 git checkout refine-entrypoint-file
-python python-image-organiser/processor.py
+git pull
+python python-image-organiser/processor.py $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-pushd /tmp/code/
-git checkout refine-entrypoint-file
-git pull
-python -u python-image-organiser/processor.py $@

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-pushd ~/code/
+pushd /tmp/code/
 git pull
-git checkout latest
+git checkout refine-entrypoint-file

--- a/python-image-organiser/processor.py
+++ b/python-image-organiser/processor.py
@@ -12,7 +12,6 @@ from image import ImageFile
 from video import VideoFile
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 formatter = logging.Formatter('%(asctime)s | %(levelname)s | %(message)s')
 
 fh = logging.FileHandler('processor.log', mode='w')
@@ -75,13 +74,13 @@ def process(src_root, dest_root, dry_run=False, delete_source=False):
         absolute_path = os.path.abspath(file)
         logger.info(f"Processing file {absolute_path}")
         if file.suffix not in file_types.keys():
-            logger.info(f"Ignoring {absolute_path} as suffix {file.suffix} not valid")
+            logger.warning(f"Ignoring {absolute_path} as suffix {file.suffix} not valid")
             continue
         if os.path.getsize(file) == 0:
-            logger.info(f"Ignoring {absolute_path} as it has size 0 bytes")
+            logger.warning(f"Ignoring {absolute_path} as it has size 0 bytes")
             continue
         if '/@eaDir/' in str(file):
-            logger.info(f"Ignoring {absolute_path} as it contains illegal pattern '/@eaDir/'")
+            logger.warning(f"Ignoring {absolute_path} as it contains illegal pattern '/@eaDir/'")
             continue
         file_class = file_types.get(file.suffix)
         valid_files.append(file_class(file, logger))


### PR DESCRIPTION
Decided to remove entrypoint file. Instead of having the docker container update the copy of the repo when it runs, it just runs with the version of the repo from the point that it was built. This means that any code changes will need to be manually deployed by rebuilding the container. This simplifies some error handling I would have had to do in the entrypoint script (what if git failed to pull?) and is just now my preferred way for this.

Also:
- Fixed log level of some logs
- Improved workflow file so it runs on all branches but only tags when on main. Formatting changes.